### PR TITLE
String may be the first string in a section

### DIFF
--- a/include/binlog/detail/read_sources.hpp
+++ b/include/binlog/detail/read_sources.hpp
@@ -42,7 +42,7 @@ inline void add_event_sources_of_file(const std::string& path, std::uintptr_t lo
   {
     for (const ElfW(Shdr)& shdr : shdrs)
     {
-      if (shdr.sh_addr < v && shdr.sh_addr + shdr.sh_size > v)
+      if (shdr.sh_addr <= v && shdr.sh_addr + shdr.sh_size > v)
       {
         return v - shdr.sh_addr + shdr.sh_offset;
       }


### PR DESCRIPTION
When searching for the correct section for a string we should consider the case where the string is the very first string in a section.